### PR TITLE
Tell node to ignore interval when considering when done

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,6 +39,7 @@ module.exports = function (duplex, min, onEnd) {
     if(Math.max(sourceRate.ts, sinkRate.ts) + min < Date.now())
       abort()
   }, 200)
+  interval.unref && interval.unref()
 
   return {
     source: pull(duplex.source, sourceRate, sourceAbort),


### PR DESCRIPTION
I have a simple sbot that connects to a peer and then disconnects right after. Sadly sbot never closes even after calling sbot.close(). I found that this fixes the problem for me. All the other intervals used in sbot has this pattern.

Code to reproduce:

```
sbot.gossip.connect(peer, err => {
  if (err) throw(err)
  else console.log("Connected to " + peer.address)

  sbot.gossip.disconnect(peer, err => {
    if (err) throw(err)
    else console.log("Disconnected from " + peer.address)
    
    sbot.close(true)
  })
})
```